### PR TITLE
Use <progress>

### DIFF
--- a/index.php
+++ b/index.php
@@ -50,9 +50,7 @@ VUmc Simulator is made by Evelien Dekkers.
         <div id="box-progress" class="box" style="display: none;">
           <h2>Please wait</h2>
           <p>We'll contact you in 2.5 years from now.</p>
-          <div id="progress">
-            <div id="progress-indication"></div>
-          </div>
+          <progress id="progress" value="0"></progress>
           <small id="progress-small">(Sped up by ten million times)</small>
         </div>
         <div id="box-question1" class="box" style="display: none;">
@@ -154,7 +152,7 @@ VUmc Simulator is made by Evelien Dekkers.
       var progressTimePast = 0;
       var progress = 0;
       var updateProgressFunc;
-      var indication = document.getElementById('progress-indication');
+      var progressBar = document.getElementById('progress');
       
       function goTo(elementId) {
         setTexts();
@@ -182,7 +180,7 @@ VUmc Simulator is made by Evelien Dekkers.
         if (progress < 100) {
           progressTimePast += progressDelay;
           progress = (progressTimePast / progressTime) * 1;
-          indication.style.width = (Math.round(progress * 100) / 100) + '%';
+          progressBar.value = Math.round(progress * 100) / 10000;
         } else {
           
           goTo('question1');

--- a/style.css
+++ b/style.css
@@ -75,8 +75,16 @@ p { font-size: 150%; margin: 10px 0; }
 button { background: #e6000f; font-weight: bold; color: white; padding: 16px; margin: 10px; cursor: pointer; border: solid 4px white; }
 button:hover { box-shadow: black 4px 4px; border: solid 4px black; }
 
-#progress { background: #eee; padding: 5px; border-radius: 999px; width: 100%; margin: 30px 0; box-sizing: border-box; }
-#progress-indication { background: #e6000f; height: 10px; border-radius: 999px; width: 0; }
+/* progress bar */
+#progress { box-sizing: border-box; height: 20px; width: 100%; margin: 30px 0; border: none; padding: 5px }
+#progress, #progress::-webkit-progress-bar { background: #eee }
+#progress, #progress::-webkit-progress-bar, #progress::-webkit-progress-value { border-radius: 99px; }
+
+/* progress value */
+#progress::-ms-fill { background: #e6000f; border-radius: 99px }
+#progress::-moz-progress-bar { background: #e6000f; border-radius: 99px }
+#progress::-webkit-progress-value { background: #e6000f; border-radius: 99px }
+
 small { display: block; font-size: 80%; }
 
 


### PR DESCRIPTION
Replaces `<div>` progress bar with `<progress>`. Includes vendor-prefixed CSS for 99% world’s used browsers.

Tested on:
- Safari 14 (build 16611)
- Firefox 91
- Edge 92 (Chromium)