### PR TITLE
Add check on whether it’s on correct screen when skipping

### DIFF
--- a/index.php
+++ b/index.php
@@ -191,7 +191,10 @@ VUmc Simulator is made by Evelien Dekkers.
       document.addEventListener('keydown', skipProgress);
       
       function skipProgress(e) {
-        if (e.code === "Space") {
+        var boxLoading = document.getElementById('box-progress');
+        
+        // Skip only the loading screen
+        if (boxLoading.style.display !== "none" && e.code === "Space") {
           goTo('question1');
         }
       }


### PR DESCRIPTION
Without the check, pressing `<space>` will put the user of the simulator to the `question1` screen regardless where they’ve progressed in the simulator. This pull request fixes that.